### PR TITLE
Implement jitter option for dataset marks

### DIFF
--- a/tikzviolinplots.sty
+++ b/tikzviolinplots.sty
@@ -53,6 +53,7 @@
 		dataset opacity=1.0,
 		dataset fill=black,
 		dataset fill opacity=0.2,
+		dataset jitter=0.0
 	},
 	col sep/.estore in = \violin@colsep,
 	kernel/.estore in = \violin@kernel,
@@ -75,6 +76,7 @@
 	dataset opacity/.estore in = \violin@pts@opacity,
 	dataset fill/.estore in = \violin@pts@fillcolor,
 	dataset fill opacity/.estore in = \violin@pts@fillopacity,
+	dataset jitter/.estore in = \violin@pts@jitter,
 	/violinplotwholefile/.is family, /violinplotwholefile,
 	default/.style = {
 		col sep=comma,
@@ -97,6 +99,7 @@
 		dataset opacity=1.0,
 		dataset fill=black,
 		dataset fill opacity=0.2,
+		dataset jitter=0.0,
 		spacing=1.0,
 		indexes={A,B,C},
 		primary color=blue,
@@ -123,6 +126,7 @@
 	dataset opacity/.estore in = \violin@batch@pts@opacity,
 	dataset fill/.estore in = \violin@batch@pts@fillcolor,
 	dataset fill opacity/.estore in = \violin@batch@pts@fillopacity,
+	dataset jitter/.estore in = \violin@batch@pts@jitter,
 	spacing/.estore in = \violin@batch@delta,
 	indexes/.estore in = \violin@batch@indexes,
 	primary color/.estore in = \violin@batch@color@primary,
@@ -599,6 +603,7 @@
 				opacity=\violin@pts@opacity,
 				fill=\violin@pts@fillcolor,
 				fill opacity=\violin@pts@fillopacity,
+				\violin@axis@x\space filter/.expression={\violin@axis@x + \violin@pts@jitter * rand}
 			] table [
 				\violin@axis@x=deltacol,
 				\violin@axis@y=\violin@index,
@@ -676,6 +681,7 @@
 			dataset opacity = \violin@batch@pts@opacity,
 			dataset fill = \violin@batch@pts@fillcolor,
 			dataset fill opacity = \violin@batch@pts@fillopacity,
+			dataset jitter = \violin@batch@pts@jitter
 		]{\violin@batch@filename}
 
 		\pgfmathparse{int(\violin@batch@counter+1)}

--- a/tikzviolinplots.tex
+++ b/tikzviolinplots.tex
@@ -343,6 +343,8 @@ comma-separated columns. The optional argument is a list of options, including:
 		\item \texttt{average fill opacity}, \texttt{dataset fill opacity}:
 			Opacity of the marks. Defaults to 0.5 for averages and
 			0.2 for the other points.
+		\item \texttt{dataset jitter}:
+			Amount by which to randomly jitter the marks. May help with distinguishing overlapping points. Defaults to $0.0$ (\textit{i.e.}, no jitter).
 	\end{itemize}
 \end{itemize}
 

--- a/tikzviolinplots.tex
+++ b/tikzviolinplots.tex
@@ -254,7 +254,7 @@ elements is shown, as in figure \ref{graph:violin_horiz}.
 The plots are mirrored by default; however, passing the option \texttt{no mirror}
 will show only half the plot, as shown in figure \ref{graph:violin_horiz}.
 
-Finally, to ``transpose'' the plots (\textit{i.e.} show the distributions
+Finally, to ``transpose'' the plots (\textit{i.e.}, show the distributions
 as functions of the abcissa, as in figure \ref{graph:violin_horiz},
 and not as functions of ordinate, as in figure \ref{graph:violin_verti}),
 one might use the option \texttt{reverse axis}.
@@ -264,7 +264,7 @@ one might use the option \texttt{reverse axis}.
 The minima and maxima of the plot axes must be set in the second (and first
 mandatory) argument to the command, and should follow \texttt{pgfplots}
 syntax. For instance, to set the minimum and maximum of the $x$-axis
-to -3 and 6, and of the $y$-axis to 2.5 and 7, one might use:
+to $-3$ and 6, and of the $y$-axis to $2.5$ and 7, one might use:
 
 \begin{minted}[escapeinside=||]{latex}
 	\violinsetoptions[|\textit{<package-specific options>}|]%
@@ -289,7 +289,7 @@ This command takes one mandatory argument, and a list of options:
 \end{minted}
 
 The filename (mandatory argument) must be a path to a file storing the data as
-space-separated columns. The optional argument is a list of options, including:
+comma-separated columns. The optional argument is a list of options, including:
 
 \begin{itemize}
 	\item \texttt{col sep}: Column separation character in filename.
@@ -471,9 +471,9 @@ Code for figure \ref{graph:violin_verti}, using
 	\violinplotwholefile[%
 		primary color=orange,
 		secondary color=black,
-		batch indexes={C,B,A,D,E},
-		batch spacing=1.0,
-		batch labels={%
+		indexes={C,B,A,D,E},
+		spacing=1.0,
+		labels={%
 			$\alpha$,
 			$\beta$,
 			$\gamma$,
@@ -861,7 +861,7 @@ code excerpt below.
 Using the key \texttt{invert=true} in the options of
 \texttt{\textbackslash violinplot} one can plot two different sets of data side
 by side, in an asymmetrical violin plot. This can be seen in figure
-\ref{graph:asymmetrical}, that exhibits the male and female life expectancy at
+\ref{graph:asymmetrical}, which exhibits the male and female life expectancy at
 birth, in 2019, for several countries, segregated in the WHO regions.\footnote{
 	\url{https://www.who.int/data/gho/publications/world-health-statistics}.
 }.
@@ -998,7 +998,7 @@ birth, in 2019, for several countries, segregated in the WHO regions.\footnote{
 	\label{graph:asymmetrical}
 \end{figure}
 
-The code for figure \ref{graph:asymmetrical} is avaliable below:
+The code for figure \ref{graph:asymmetrical} is available below:
 
 \begin{minted}[%
 	escapeinside=||,


### PR DESCRIPTION
Apart from fixing some very minor issues in the package's documentation, this PR adds a new `dataset jitter` option. When this is set to a non-zero value, the dataset marks will be jittered (i.e., randomly moved along the axis they're on) by the given value.
The intention is to make overlapping points more easily distinguishable (especially if they are fully opaque).

As an example of what this looks like, here's the "vertical example" plot from the package documentation with a jitter of 0.1:
![image](https://github.com/user-attachments/assets/e7f149cf-40b6-4148-9f0b-a209ca6f01e5)
